### PR TITLE
Distribute a pkg-config .pc file

### DIFF
--- a/libjulius/Makefile.in
+++ b/libjulius/Makefile.in
@@ -29,12 +29,14 @@ exec_prefix=@exec_prefix@
 bindir=@bindir@
 libdir=@libdir@
 includedir=@includedir@
+pkgconfigdir = $(libdir)/pkgconfig
 INSTALL=@INSTALL@
 INSTALL_DATA=@INSTALL_DATA@
 INSTALL_PROGRAM=@INSTALL_PROGRAM@
 
 ############################################################
 
+PKGCONF_FILE = julius-@JULIUS_MAJOR_VERSION@.pc
 TARGET = libjulius.a
 
 OBJ = \
@@ -93,6 +95,7 @@ install: install.lib install.include install.bin
 install.lib: $(TARGET)
 	${INSTALL} -d ${libdir}
 	${INSTALL_DATA} $(TARGET) ${libdir}
+	${INSTALL_DATA} $(PKGCONF_FILE) ${pkgconfigdir}
 
 install.include:
 	${INSTALL} -d ${includedir}/julius
@@ -120,6 +123,7 @@ distclean:
 	$(RM) src/version.c
 	$(RM) libjulius-config libjulius-config-dist
 	$(RM) doxygen.conf.ver
+	$(RM) $(PKGCONF_FILE)
 	$(RM) config.status include/julius/config.h
 	$(RM) Makefile
 

--- a/libjulius/configure
+++ b/libjulius/configure
@@ -587,6 +587,8 @@ ac_subst_vars='LTLIBOBJS
 LIBOBJS
 easy_setup
 JULIUS_VERSION
+JULIUS_MINOR_VERSION
+JULIUS_MAJOR_VERSION
 JULIUS_PRODUCTNAME
 EGREP
 GREP
@@ -1982,7 +1984,9 @@ ac_configure="$SHELL $ac_aux_dir/configure"  # Please don't use this var.
 
 
 JULIUS_PRODUCTNAME=JuliusLib
-JULIUS_VERSION=4.4
+JULIUS_MAJOR_VERSION=4
+JULIUS_MINOR_VERSION=4
+JULIUS_VERSION=${JULIUS_MAJOR_VERSION}.${JULIUS_MINOR_VERSION}
 
 
 # Check whether --enable-pthread was given.
@@ -4138,9 +4142,11 @@ _ACEOF
 
 
 
+
+
 ac_config_commands="$ac_config_commands default-1"
 
-ac_config_files="$ac_config_files Makefile libjulius-config libjulius-config-dist src/version.c doxygen.conf.ver"
+ac_config_files="$ac_config_files Makefile libjulius-config libjulius-config-dist julius-$JULIUS_MAJOR_VERSION.pc:julius.pc.in src/version.c doxygen.conf.ver"
 
 cat >confcache <<\_ACEOF
 # This file is a shell script that caches the results of configure
@@ -4846,6 +4852,7 @@ do
     "Makefile") CONFIG_FILES="$CONFIG_FILES Makefile" ;;
     "libjulius-config") CONFIG_FILES="$CONFIG_FILES libjulius-config" ;;
     "libjulius-config-dist") CONFIG_FILES="$CONFIG_FILES libjulius-config-dist" ;;
+    "julius-$JULIUS_MAJOR_VERSION.pc") CONFIG_FILES="$CONFIG_FILES julius-$JULIUS_MAJOR_VERSION.pc:julius.pc.in" ;;
     "src/version.c") CONFIG_FILES="$CONFIG_FILES src/version.c" ;;
     "doxygen.conf.ver") CONFIG_FILES="$CONFIG_FILES doxygen.conf.ver" ;;
 

--- a/libjulius/configure.in
+++ b/libjulius/configure.in
@@ -12,7 +12,9 @@ AC_CONFIG_HEADER(include/julius/config.h)
 AC_CONFIG_AUX_DIR(../support)
 
 JULIUS_PRODUCTNAME=JuliusLib
-JULIUS_VERSION=4.4
+JULIUS_MAJOR_VERSION=4
+JULIUS_MINOR_VERSION=4
+JULIUS_VERSION=${JULIUS_MAJOR_VERSION}.${JULIUS_MINOR_VERSION}
 
 dnl Checks for options
 
@@ -383,10 +385,12 @@ AC_DEFINE_UNQUOTED(JULIUS_VERSION, "$JULIUS_VERSION")
 AC_DEFINE_UNQUOTED(JULIUS_SETUP, "$easy_setup")
 AC_DEFINE_UNQUOTED(JULIUS_HOSTINFO, "$host")
 AC_SUBST(JULIUS_PRODUCTNAME)
+AC_SUBST(JULIUS_MAJOR_VERSION)
+AC_SUBST(JULIUS_MINOR_VERSION)
 AC_SUBST(JULIUS_VERSION)
 AC_SUBST(easy_setup)
 
 AC_OUTPUT_COMMANDS(
 [chmod +x libjulius-config libjulius-config-dist
 ])
-AC_OUTPUT(Makefile libjulius-config libjulius-config-dist src/version.c doxygen.conf.ver)
+AC_OUTPUT(Makefile libjulius-config libjulius-config-dist julius-$JULIUS_MAJOR_VERSION.pc:julius.pc.in src/version.c doxygen.conf.ver)

--- a/libjulius/julius.pc.in
+++ b/libjulius/julius.pc.in
@@ -1,0 +1,10 @@
+prefix=@prefix@
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=${exec_prefix}/include
+
+Name: @JULIUS_PRODUCTNAME@
+Description: @JULIUS_PRODUCTNAME@ is the C library for Julius speech recognition suite
+Version: @JULIUS_VERSION@
+Libs: -ljulius @LDFLAGS@ @LIBS@
+Cflags: -I@includedir@ @CPPFLAGS@


### PR DESCRIPTION
The pkg-config tool allows projects to query which packages
are installed on the target system in a distro-agnostic way.
It does so by reading a .pc file that is installed by each
individual package.

JuliusLib, which is the shared module of Julius, is intended
to be distributed and used, along the provided headers, through
a statically-linked library. It doesn't, however, install a .pc
file so applications can check whether JuliusLib is installed
or not.

This patch adds julius.pc.in file to the project tree, and adapts
the build files to generate a .pc file and install it. The generated
pkg-config file is distributed according to the major version,
and is filled in during compile-time.

https://github.com/julius-speech/julius/issues/33