### PR TITLE
libsent: unconditionally include avx target

### DIFF
--- a/libsent/configure
+++ b/libsent/configure
@@ -3277,6 +3277,7 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 xxxxAVX=yes
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for SIMD AVX instruction" >&5
 $as_echo_n "checking for SIMD AVX instruction... " >&6; }
+CFLAGS="$CFLAGS -mavx"
 
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
@@ -3301,28 +3302,7 @@ xxxxAVX=no
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 if test "$xxxxAVX" = no; then
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for SIMD AVX instruction with -mavx" >&5
-$as_echo_n "checking for SIMD AVX instruction with -mavx... " >&6; }
-  CFLAGS="$CFLAGS -mavx"
-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-#include <immintrin.h>
-
-int
-main ()
-{
-__m256 v;
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-else
   as_fn_error $? "no support for SIMD AVX instruction" "$LINENO" 5
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
 # Find a good install program.  We prefer a C program (faster),

--- a/libsent/configure.in
+++ b/libsent/configure.in
@@ -127,6 +127,7 @@ AC_PROG_CPP
 dnl Checks for AVX capability
 xxxxAVX=yes
 AC_MSG_CHECKING([for SIMD AVX instruction])
+CFLAGS="$CFLAGS -mavx"
 AC_TRY_COMPILE([#include <immintrin.h>
 ],[__m256 v;],
 AC_MSG_RESULT([yes]),
@@ -134,13 +135,7 @@ AC_MSG_RESULT([no])
 xxxxAVX=no
 )
 if test "$xxxxAVX" = no; then
-  dnl retry with "-mavx" option
-  AC_MSG_CHECKING([for SIMD AVX instruction with -mavx])
-  CFLAGS="$CFLAGS -mavx"
-  AC_TRY_COMPILE([#include <immintrin.h>
-  ],[__m256 v;],
-  AC_MSG_RESULT([yes]),
-    AC_MSG_ERROR([no support for SIMD AVX instruction]))
+  AC_MSG_ERROR([no support for SIMD AVX instruction])
 fi
 
 dnl Checks for programs.


### PR DESCRIPTION
Libsent uses avx features, but is not sets the
avx2 target, which causes various compiler errors
and breaks the building of libsent.

The compile-time errors are caused because the
configure script only adds '-mavx' target to CFLAGS
when the test import goes wrong. On standard systems,
however, the test import runs ok but we still need
to set the '-mavx' target.

Fix that by always adding avx target to CFLAGS.

[julius-speech/julius#37]