### PR TITLE
m_info: remove duplicated log entry

### DIFF
--- a/libjulius/src/m_info.c
+++ b/libjulius/src/m_info.c
@@ -960,7 +960,6 @@ print_engine_info(Recog *recog)
     } else {
       jlog("\t    long-term DC removal = off\n");
     }
-    jlog("\t    long-term DC removal = off\n");
     if (jconf->preprocess.level_coef != 1.0) {
       jlog("\t    level scaling factor = %.2f\n", jconf->preprocess.level_coef);
     } else {


### PR DESCRIPTION
The "long-term DC removal = off" is inconditionally
printed, even if the ZMean flag is on.

Fix that by removing the wrong log dispatch.

[julius-speech/julius#43]