### PR TITLE
ensure pkgconfig directory exists during installation

### DIFF
--- a/libjulius/Makefile.in
+++ b/libjulius/Makefile.in
@@ -95,6 +95,7 @@ install: install.lib install.include install.bin
 install.lib: $(TARGET)
 	${INSTALL} -d ${libdir}
 	${INSTALL_DATA} $(TARGET) ${libdir}
+	${INSTALL} -d ${pkgconfigdir}
 	${INSTALL_DATA} $(PKGCONF_FILE) ${pkgconfigdir}
 
 install.include:

--- a/libsent/Makefile.in
+++ b/libsent/Makefile.in
@@ -170,6 +170,7 @@ install: install.lib install.include install.bin
 install.lib: $(TARGET)
 	${INSTALL} -d ${libdir}
 	${INSTALL_DATA} $(TARGET) ${libdir}
+	${INSTALL} -d ${pkgconfigdir}
 	${INSTALL_DATA} $(PKGCONF_FILE) ${pkgconfigdir}
 
 install.include:


### PR DESCRIPTION
Fixes #72.

This ensures that the `lib/pkgconfig` directory is created if it doesn't exist, so the pkgconfig data files are installed properly.