### PR TITLE
Fix AArch64 GNU/Linux build

### DIFF
--- a/libsent/src/phmm/calc_dnn.c
+++ b/libsent/src/phmm/calc_dnn.c
@@ -12,7 +12,7 @@
 #ifdef _WIN32
 #include <intrin.h>
 #else
-#if defined(__arm__) || TARGET_OS_IPHONE
+#if defined(__arm__) || TARGET_OS_IPHONE || defined(__aarch64__)
 #else
 #include <cpuid.h>
 #endif


### PR DESCRIPTION
I have no idea that this is a correct fix, but I've got build failure on AArch64 Linux board.
 
Tested on Jetson TX2 Ubuntu 16.04 (Xenial).

Otherwise, the following error occurred:

```log
$ ./configure --build=aarch64-unknown-linux-gnu
# take a few time...
$ make -j 6
# take a few time...
make[1]: Entering directory '/home/nvidia/GitHub/julius/libsent'
gcc -g -O2 -fopenmp -Iinclude   -DHAVE_CONFIG_H -o src/phmm/calc_dnn.o -c src/phmm/calc_dnn.c
src/phmm/calc_dnn.c:17:19: fatal error: cpuid.h: No such file or directory
compilation terminated.
Makefile:12: recipe for target 'src/phmm/calc_dnn.o' failed
make[1]: *** [src/phmm/calc_dnn.o] Error 1
make[1]: Leaving directory '/home/nvidia/GitHub/julius/libsent'
Makefile:56: recipe for target 'libsent' failed
make: *** [libsent] Error 2
```