### PR TITLE
grammar search on the 1st pass

### DIFF
--- a/gramtools/mkdfa/mkdfa.pl.in
+++ b/gramtools/mkdfa/mkdfa.pl.in
@@ -200,13 +200,15 @@ if ($make_dict == 1) {
     close(DICT);
 }
 
-$gene = "$dfafile $fdfafile";
+$gene = "$dfafile";
 if ($make_term == 1) {
     $gene .= " $termfile";
 }
 if ($make_dict == 1) {
     $gene .= " $dictfile";
 }
+$gene .= " $fdfafile";
+
 print "generated: $gene\n";
 
 sub usage {

--- a/gramtools/mkdfa/mkdfa.pl.in
+++ b/gramtools/mkdfa/mkdfa.pl.in
@@ -59,6 +59,7 @@ if ($gramprefix eq "") {
 $gramfile = "$ARGV[$#ARGV].grammar";
 $vocafile = "$ARGV[$#ARGV].voca";
 $dfafile  = "$ARGV[$#ARGV].dfa";
+$fdfafile  = "$ARGV[$#ARGV].dfa.forward";
 $dictfile = "$ARGV[$#ARGV].dict";
 $termfile = "$ARGV[$#ARGV].term";
 $tmpprefix = "$tmpdir/g$$";
@@ -140,20 +141,27 @@ if (! -x $minimizebin) {
     print "Warning: no minimization performed\n";
     if ($tmpprefix =~ /cygdrive/) {
 	$status = system("$mkfabin -e1 -fg `cygpath -w $rgramfile` -fv `cygpath -w $tmpvocafile` -fo `cygpath -w $dfafile` -fh `cygpath -w ${tmpprefix}.h`");
+	$status = system("$mkfabin -e1 -fg `cygpath -w $gramfile` -fv `cygpath -w $tmpvocafile` -fo `cygpath -w $fdfafile` -fh `cygpath -w ${tmpprefix}.h`");
     } else {
 	$status = system("$mkfabin -e1 -fg $rgramfile -fv $tmpvocafile -fo $dfafile -fh ${tmpprefix}.h");
+	$status = system("$mkfabin -e1 -fg $gramfile -fv $tmpvocafile -fo $fdfafile -fh ${tmpprefix}.h");
     }
 } else {
     # minimize DFA after generation
     if ($tmpprefix =~ /cygdrive/) {
 	$status = system("$mkfabin -e1 -fg `cygpath -w $rgramfile` -fv `cygpath -w $tmpvocafile` -fo `cygpath -w ${dfafile}.tmp` -fh `cygpath -w ${tmpprefix}.h`");
 	system("$minimizebin `cygpath -w ${dfafile}.tmp` -o `cygpath -w $dfafile`");
+	$status = system("$mkfabin -e1 -fg `cygpath -w $gramfile` -fv `cygpath -w $tmpvocafile` -fo `cygpath -w ${dfafile}.tmp` -fh `cygpath -w ${tmpprefix}.h`");
+	system("$minimizebin `cygpath -w ${dfafile}.tmp` -o `cygpath -w $fdfafile`");
     } else {
 	$status = system("$mkfabin -e1 -fg $rgramfile -fv $tmpvocafile -fo ${dfafile}.tmp -fh ${tmpprefix}.h");
 	system("$minimizebin ${dfafile}.tmp -o $dfafile");
+	$status = system("$mkfabin -e1 -fg $gramfile -fv $tmpvocafile -fo ${dfafile}.tmp -fh ${tmpprefix}.h");
+	system("$minimizebin ${dfafile}.tmp -o $fdfafile");
     }
     unlink("${dfafile}.tmp");
 }
+
 unlink("$rgramfile");
 unlink("$tmpvocafile");
 unlink("${tmpprefix}.h");
@@ -192,7 +200,7 @@ if ($make_dict == 1) {
     close(DICT);
 }
 
-$gene = "$dfafile";
+$gene = "$dfafile $fdfafile";
 if ($make_term == 1) {
     $gene .= " $termfile";
 }

--- a/gramtools/mkdfa/mkdfa.py
+++ b/gramtools/mkdfa/mkdfa.py
@@ -57,6 +57,7 @@ def extract_vocafile(src, catefile, termfile):
 
     with codecs.open(src, "r", 'utf-8') as fin:
         for line in fin:
+            line = re.sub('#.*$', "", line)
             if len(line.strip()) == 0:
                 continue
             if line.find('%') == 0:
@@ -83,6 +84,7 @@ def vocafile2dictfile(vocafile, dictfile):
         with codecs.open(dictfile, "w", 'utf-8') as fout:
             id = -1
             for line in fin:
+                line = re.sub('#.*$', "", line)
                 line = line.strip()
                 if len(line) == 0:
                     continue
@@ -138,6 +140,7 @@ if __name__ == '__main__':
     dfafile  = corename + ".dfa"
     dictfile = corename + ".dict"
     termfile = corename + ".term"
+    fdfafile = corename + ".dfa.forward"
 
     tmpprefix   = tempfile.gettempdir() + "/_julius_mkdfa_tmp_"
     tmpvocafile = tmpprefix + ".voca"
@@ -151,12 +154,16 @@ if __name__ == '__main__':
 
     print('---')
 
+    # call mkfa to generate .dfa from reversed grammar (and minimize) 
     call_mkfa(rgramfile, tmpvocafile, dfafile, tmpprefix)
+    
+    # call mkfa to generate .dfa_forward from original grammar (and minimize) 
+    call_mkfa(gramfile, tmpvocafile, fdfafile, tmpprefix)
 
     vocafile2dictfile(vocafile, dictfile)
 
     print('---')
-    print("generated %s %s %s" % (dfafile, termfile, dictfile))
+    print("generated %s %s %s %s" % (dfafile, termfile, dictfile, fdfafile))
 
     os.unlink(tmpvocafile)
     os.unlink(rgramfile)

--- a/julius/module.c
+++ b/julius/module.c
@@ -280,7 +280,7 @@ msock_exec_command(char *command, Recog *recog)
 	/* delete all existing grammars */
 	multigram_delete_all(cur->lm);
 	/* register the new grammar to multi-gram tree */
-	multigram_add(new_dfa, new_winfo, p, cur->lm);
+	multigram_add(new_dfa, new_winfo, p, cur->lm, NULL);
 	/* need to rebuild the global lexicon */
 	/* tell engine to update at requested timing */
 	schedule_grammar_update(recog);
@@ -312,7 +312,7 @@ msock_exec_command(char *command, Recog *recog)
     } else {
       if (cur->lmtype == LM_DFA) {
 	/* add it to multi-gram tree */
-	multigram_add(new_dfa, new_winfo, p, cur->lm);
+	multigram_add(new_dfa, new_winfo, p, cur->lm, NULL);
 	/* need to rebuild the global lexicon */
 	/* make sure this process will be activated */
 	cur->active = 1;

--- a/libjulius/include/julius/beam.h
+++ b/libjulius/include/julius/beam.h
@@ -38,7 +38,7 @@ typedef struct {
   LOGPROB last_lscore;		///< Currently assigned word-internal LM score for factoring for N-gram
   LOGPROB score;		///< Current accumulated score (AM+LM)
   int node;			///< Lexicon node ID to which this token is assigned
-  int to_state;                 ///< DFA to state
+  int to_state;                 ///< Forward DFA state id to which this token goes
 #ifdef WPAIR
   TOKENID next;			///< ID pointer to next token at same node, for word-pair approx.
 #endif

--- a/libjulius/include/julius/beam.h
+++ b/libjulius/include/julius/beam.h
@@ -38,6 +38,7 @@ typedef struct {
   LOGPROB last_lscore;		///< Currently assigned word-internal LM score for factoring for N-gram
   LOGPROB score;		///< Current accumulated score (AM+LM)
   int node;			///< Lexicon node ID to which this token is assigned
+  int to_state;                 ///< DFA to state
 #ifdef WPAIR
   TOKENID next;			///< ID pointer to next token at same node, for word-pair approx.
 #endif

--- a/libjulius/include/julius/extern.h
+++ b/libjulius/include/julius/extern.h
@@ -249,7 +249,7 @@ void jconf_set_default_values_search(JCONF_SEARCH *j);
 
 
 /* multi-gram.c */
-int multigram_add(DFA_INFO *dfa, WORD_INFO *winfo, char *name, PROCESS_LM *lm);
+int multigram_add(DFA_INFO *dfa, WORD_INFO *winfo, char *name, PROCESS_LM *lm, DFA_INFO *dfa_forward);
 boolean multigram_delete(int gid, PROCESS_LM *lm);
 void multigram_delete_all(PROCESS_LM *lm);
 boolean multigram_update(PROCESS_LM *lm);

--- a/libjulius/include/julius/multi-gram.h
+++ b/libjulius/include/julius/multi-gram.h
@@ -33,6 +33,7 @@ typedef struct __multi_gram__ {
   char name[MAXGRAMNAMELEN];	///< Unique name given by user
   unsigned short id;		///< Unique ID 
   DFA_INFO *dfa;		///< DFA describing syntax of this grammar
+  DFA_INFO *dfa_forward;		///< additional forward DFA describing syntax of this grammar
   WORD_INFO *winfo;		///< Dictionary of this grammar
   int hook;			///< Work area to store command hook
   boolean newbie;		///< TRUE if just read and not yet configured
@@ -41,6 +42,7 @@ typedef struct __multi_gram__ {
   int state_begin;		///< Location of DFA states in the global grammar
   int cate_begin;		///< Location of category entries in the global grammar
   int word_begin;		///< Location of words in the dictionary of global grammar
+  int state_begin_forward;
   struct __multi_gram__ *next;	///< Link to the next grammar entry
 } MULTIGRAM;
 

--- a/libjulius/include/julius/multi-gram.h
+++ b/libjulius/include/julius/multi-gram.h
@@ -33,7 +33,7 @@ typedef struct __multi_gram__ {
   char name[MAXGRAMNAMELEN];	///< Unique name given by user
   unsigned short id;		///< Unique ID 
   DFA_INFO *dfa;		///< DFA describing syntax of this grammar
-  DFA_INFO *dfa_forward;		///< additional forward DFA describing syntax of this grammar
+  DFA_INFO *dfa_forward;	///< additional forward DFA
   WORD_INFO *winfo;		///< Dictionary of this grammar
   int hook;			///< Work area to store command hook
   boolean newbie;		///< TRUE if just read and not yet configured
@@ -42,7 +42,7 @@ typedef struct __multi_gram__ {
   int state_begin;		///< Location of DFA states in the global grammar
   int cate_begin;		///< Location of category entries in the global grammar
   int word_begin;		///< Location of words in the dictionary of global grammar
-  int state_begin_forward;
+  int state_begin_forward;      ///< Location of forward DFA states in the global forward grammar
   struct __multi_gram__ *next;	///< Link to the next grammar entry
 } MULTIGRAM;
 

--- a/libjulius/include/julius/recog.h
+++ b/libjulius/include/julius/recog.h
@@ -865,6 +865,12 @@ typedef struct __process_lm__ {
   DFA_INFO *dfa;
 
   /**
+   * Global Forward DFA for recognition.  This will be generated from @a grammars,
+   * concatinating each forward DFA into one.
+   */
+  DFA_INFO *dfa_forward;
+
+  /**
    * TRUE if modified in multigram_update()
    * 
    */

--- a/libjulius/include/julius/recog.h
+++ b/libjulius/include/julius/recog.h
@@ -142,6 +142,7 @@ typedef struct __FSBeam__ {
 
   int totalnodenum;     ///< Allocated number of nodes in @a token
   TRELLIS_ATOM bos;     ///< Special token for beginning-of-sentence
+  TRELLIS_ATOM *boslist; ///< List of BOS for multi-grammar forward DFA
   boolean nodes_malloced; ///< Flag to check if tokens already allocated
   LOGPROB lm_weight;           ///< Language score weight (local copy)
   LOGPROB lm_penalty;          ///< Word insertion penalty (local copy)

--- a/libjulius/include/julius/trellis.h
+++ b/libjulius/include/julius/trellis.h
@@ -31,7 +31,7 @@ typedef struct __trellis_atom__ {
   WORD_ID wid;			///< Word ID
   short begintime;		///< Beginning frame
   short endtime;		///< End frame
-  int dfa_state;                ///< DFA state id
+  int dfa_state;                ///< Forward DFA state id, when run with forward dfa
 #ifdef WORD_GRAPH
   boolean within_wordgraph;	///< TRUE if within word graph
   boolean within_context;	///< TRUE if any of its following word was once survived in beam while search

--- a/libjulius/include/julius/trellis.h
+++ b/libjulius/include/julius/trellis.h
@@ -31,6 +31,7 @@ typedef struct __trellis_atom__ {
   WORD_ID wid;			///< Word ID
   short begintime;		///< Beginning frame
   short endtime;		///< End frame
+  int dfa_state;                ///< DFA state id
 #ifdef WORD_GRAPH
   boolean within_wordgraph;	///< TRUE if within word graph
   boolean within_context;	///< TRUE if any of its following word was once survived in beam while search

--- a/libjulius/include/julius/wchmm.h
+++ b/libjulius/include/julius/wchmm.h
@@ -215,7 +215,7 @@ typedef struct wchmm_info {
   HTK_HMM_INFO *hmminfo;	///< HMM definitions used to construct this lexicon
   NGRAM_INFO *ngram;		///< N-gram used to construct this lexicon
   DFA_INFO *dfa;		///< Grammar used to construct this lexicon
-  DFA_INFO *dfa_forward;	///< Grammar used to construct this lexicon
+  DFA_INFO *dfa_forward;	///< Additional forward grammar for dynamic constraints
   WORD_INFO *winfo;		///< Word dictionary used to construct this lexicon
   boolean ccd_flag;		///< TRUE if handling context dependency
   int	maxwcn;			///< Memory assigned maximum number of nodes

--- a/libjulius/include/julius/wchmm.h
+++ b/libjulius/include/julius/wchmm.h
@@ -215,6 +215,7 @@ typedef struct wchmm_info {
   HTK_HMM_INFO *hmminfo;	///< HMM definitions used to construct this lexicon
   NGRAM_INFO *ngram;		///< N-gram used to construct this lexicon
   DFA_INFO *dfa;		///< Grammar used to construct this lexicon
+  DFA_INFO *dfa_forward;	///< Grammar used to construct this lexicon
   WORD_INFO *winfo;		///< Word dictionary used to construct this lexicon
   boolean ccd_flag;		///< TRUE if handling context dependency
   int	maxwcn;			///< Memory assigned maximum number of nodes

--- a/libjulius/src/beam.c
+++ b/libjulius/src/beam.c
@@ -1581,6 +1581,7 @@ init_nodescore(HTK_Param *param, RecogProcess *r)
   }
 
   d->bos.begintime = d->bos.endtime = -1;
+  d->bos.dfa_state = 0;
 
   /* ノード・トークンを初期化 */
   /* clear tree lexicon nodes and tokens */
@@ -1718,6 +1719,17 @@ init_nodescore(HTK_Param *param, RecogProcess *r)
 	      } else {
 		new->score = outprob_style(wchmm, node, d->bos.wid, 0, param) + new->last_lscore;
 	      }
+
+	      new->to_state = -1;
+	      if (wchmm->dfa_forward) {
+		for (DFA_ARC *ac = wchmm->dfa_forward->st[new->last_tre->dfa_state].arc; ac; ac = ac->next) {
+		  if (ac->label == t) {
+		    new->to_state = ac->to_state;
+		    break;
+		  }
+		}
+	      }
+	      
 	      node_assign_token(d, node, newid);
 	    }
 	  }
@@ -1912,7 +1924,7 @@ get_back_trellis_init(HTK_Param *param,	RecogProcess *r)
  * 
  */
 static void
-propagate_token(FSBeam *d, int next_node, LOGPROB next_score, TRELLIS_ATOM *last_tre, WORD_ID last_cword, LOGPROB last_lscore)
+propagate_token(FSBeam *d, int next_node, LOGPROB next_score, TRELLIS_ATOM *last_tre, WORD_ID last_cword, LOGPROB last_lscore, int to_state)
 {
   TOKEN2 *tknext;
   TOKENID tknextid;
@@ -1931,6 +1943,7 @@ propagate_token(FSBeam *d, int next_node, LOGPROB next_score, TRELLIS_ATOM *last
       tknext->last_cword = last_cword; /* propagate last context word info */
       tknext->last_lscore = last_lscore; /* set new LM score */
       tknext->score = next_score; /* set new score */
+      tknext->to_state = to_state;
     }
   } else {
     /* 遷移先ノードは未伝搬: 新規トークンを作って割り付ける */
@@ -1940,6 +1953,7 @@ propagate_token(FSBeam *d, int next_node, LOGPROB next_score, TRELLIS_ATOM *last
     tknext->last_tre = last_tre; /* propagate last word info */
     tknext->last_cword = last_cword; /* propagate last context word info */
     tknext->last_lscore = last_lscore;
+    tknext->to_state = to_state;
     tknext->score = next_score; /* set new score */
     node_assign_token(d, next_node, tknextid); /* assign this new token to the next node */
   }
@@ -2085,7 +2099,7 @@ beam_intra_word_core(WCHMM_INFO *wchmm, FSBeam *d, TOKEN2 **tk_ret, int j, int n
   /****************************************/
   
   if (ngram_score_cache == LOG_ZERO) ngram_score_cache = tk->last_lscore;
-  propagate_token(d, next_node, tmpsum, tk->last_tre, tk->last_cword, ngram_score_cache);
+  propagate_token(d, next_node, tmpsum, tk->last_tre, tk->last_cword, ngram_score_cache, tk->to_state);
   
   if (d->expanded) {
     /* if work area has been expanded at 'create_token()' above,
@@ -2196,6 +2210,7 @@ save_trellis(BACKTRELLIS *bt, WCHMM_INFO *wchmm, TOKEN2 *tk, int t, boolean fina
   tre->endtime   = t-1;	/* word end frame */
   tre->last_tre  = tk->last_tre; /* link to previous trellis word */
   tre->lscore    = tk->last_lscore;	/* log LM score  */
+  tre->dfa_state = tk->to_state;
   bt_store(bt, tre); /* save to backtrellis */
 #ifdef WORD_GRAPH
   if (tre->last_tre != NULL) {
@@ -2249,6 +2264,7 @@ beam_inter_word(WCHMM_INFO *wchmm, FSBeam *d, TOKEN2 **tk_ret, TRELLIS_ATOM *tre
   LOGPROB tmpprob, tmpsum, ngram_score_cache;
   int k;
   WORD_ID last_word;
+  int next_state = -1;
 
   tk = *tk_ret;
  
@@ -2374,6 +2390,18 @@ beam_inter_word(WCHMM_INFO *wchmm, FSBeam *d, TOKEN2 **tk_ret, TRELLIS_ATOM *tre
 	 do not allow transition if the category connection is not allowed
 	 (with category tree, constraint can be determined on top node) */
       if (dfa_cp(wchmm->dfa, wchmm->winfo->wton[sword], wchmm->winfo->wton[wchmm->start2wid[stid]]) == FALSE) continue;
+
+      if (wchmm->dfa_forward) {
+	next_state = -1;
+	for (DFA_ARC *ac = wchmm->dfa_forward->st[tk->to_state].arc; ac; ac = ac->next) {
+	  if (ac->label == wchmm->winfo->wton[wchmm->start2wid[stid]]) {
+	    next_state = ac->to_state;
+	    break;
+	  }
+	}
+	if (next_state == -1) continue;
+      }
+      
     }
 
     /*******************************************************************/
@@ -2420,7 +2448,7 @@ beam_inter_word(WCHMM_INFO *wchmm, FSBeam *d, TOKEN2 **tk_ret, TRELLIS_ATOM *tre
     if (wchmm->hmminfo->multipath) {
       /* since top node has no ouput, we should go one more step further */
       if (wchmm->self_a[next_node] != LOG_ZERO) {
-	propagate_token(d, next_node, tmpsum + wchmm->self_a[next_node], tre, last_word, ngram_score_cache);
+	propagate_token(d, next_node, tmpsum + wchmm->self_a[next_node], tre, last_word, ngram_score_cache, next_state);
 	if (d->expanded) {
 	  /* if work area has been expanded at 'create_token()' above,
 	     the inside 'realloc()' will destroy the pointers.
@@ -2430,7 +2458,7 @@ beam_inter_word(WCHMM_INFO *wchmm, FSBeam *d, TOKEN2 **tk_ret, TRELLIS_ATOM *tre
 	}
       }
       if (wchmm->next_a[next_node] != LOG_ZERO) {
-	propagate_token(d, next_node+1, tmpsum + wchmm->next_a[next_node], tre, last_word, ngram_score_cache);
+	propagate_token(d, next_node+1, tmpsum + wchmm->next_a[next_node], tre, last_word, ngram_score_cache, next_state);
 	if (d->expanded) {
 	  /* if work area has been expanded at 'create_token()' above,
 	     the inside 'realloc()' will destroy the pointers.
@@ -2441,7 +2469,7 @@ beam_inter_word(WCHMM_INFO *wchmm, FSBeam *d, TOKEN2 **tk_ret, TRELLIS_ATOM *tre
       }
       for(ac=wchmm->ac[next_node];ac;ac=ac->next) {
 	for(k=0;k<ac->n;k++) {
-	  propagate_token(d, ac->arc[k], tmpsum + ac->a[k], tre, last_word, ngram_score_cache);
+	  propagate_token(d, ac->arc[k], tmpsum + ac->a[k], tre, last_word, ngram_score_cache, next_state);
 	  if (d->expanded) {
 	    /* if work area has been expanded at 'create_token()' above,
 	       the inside 'realloc()' will destroy the pointers.
@@ -2452,7 +2480,7 @@ beam_inter_word(WCHMM_INFO *wchmm, FSBeam *d, TOKEN2 **tk_ret, TRELLIS_ATOM *tre
 	}
       }
     } else {
-      propagate_token(d, next_node, tmpsum, tre, last_word, ngram_score_cache);
+      propagate_token(d, next_node, tmpsum, tre, last_word, ngram_score_cache, next_state);
       if (d->expanded) {
 	/* if work area has been expanded at 'create_token()' above,
 	   the inside 'realloc()' will destroy the pointers.
@@ -2538,20 +2566,20 @@ beam_inter_word_factoring(WCHMM_INFO *wchmm, FSBeam *d)
     if (wchmm->hmminfo->multipath) {
       /* since top node has no ouput, we should go one more step further */
       if (wchmm->self_a[next_node] != LOG_ZERO) {
-	propagate_token(d, next_node, tmpsum + wchmm->self_a[next_node], d->wordend_best_tre, last_word, ngram_score_cache);
+	propagate_token(d, next_node, tmpsum + wchmm->self_a[next_node], d->wordend_best_tre, last_word, ngram_score_cache, -1);
 	if (d->expanded) {
 	  d->expanded = FALSE;
 	}
       }
       if (wchmm->next_a[next_node] != LOG_ZERO) {
-	propagate_token(d, next_node+1, tmpsum + wchmm->next_a[next_node], d->wordend_best_tre, last_word, ngram_score_cache);
+	propagate_token(d, next_node+1, tmpsum + wchmm->next_a[next_node], d->wordend_best_tre, last_word, ngram_score_cache, -1);
 	if (d->expanded) {
 	  d->expanded = FALSE;
 	}
       }
       for(ac=wchmm->ac[next_node];ac;ac=ac->next) {
 	for(j=0;j<ac->n;j++) {
-	  propagate_token(d, ac->arc[j], tmpsum + ac->a[j], d->wordend_best_tre, last_word, ngram_score_cache);
+	  propagate_token(d, ac->arc[j], tmpsum + ac->a[j], d->wordend_best_tre, last_word, ngram_score_cache, -1);
 	  if (d->expanded) {
 	    d->expanded = FALSE;
 	  }
@@ -2559,7 +2587,7 @@ beam_inter_word_factoring(WCHMM_INFO *wchmm, FSBeam *d)
       }
       
     } else {
-      propagate_token(d, next_node, tmpsum, d->wordend_best_tre, last_word, ngram_score_cache);
+      propagate_token(d, next_node, tmpsum, d->wordend_best_tre, last_word, ngram_score_cache, -1);
       if (d->expanded) {
 	d->expanded = FALSE;
       }

--- a/libjulius/src/instance.c
+++ b/libjulius/src/instance.c
@@ -243,6 +243,7 @@ j_process_lm_free(PROCESS_LM *lm)
   if (lm->ngram) ngram_info_free(lm->ngram);
   if (lm->grammars) multigram_free_all(lm->grammars);
   if (lm->dfa) dfa_info_free(lm->dfa);
+  if (lm->dfa_forward) dfa_info_free(lm->dfa_forward);
   /* not free lm->jconf  */
   free(lm);
 }

--- a/libjulius/src/m_info.c
+++ b/libjulius/src/m_info.c
@@ -453,6 +453,10 @@ print_engine_info(Recog *recog)
 	    print_dfa_cp(fp, lm->dfa);
 	    jlog("\n");
 	  }
+	  if (lm->dfa_forward) {
+	    jlog(" additional forward");
+	    print_dfa_info(fp, lm->dfa_forward); jlog("\n");
+	  }
 	}
       } else if (lm->lmvar == LM_DFA_WORD) {
 	jlog(" type=word\n\n");

--- a/libjulius/src/multi-gram.c
+++ b/libjulius/src/multi-gram.c
@@ -221,6 +221,7 @@ multigram_append_to_global(DFA_INFO *gdfa, WORD_INFO *gwinfo, DFA_INFO *gdfa_for
   /* Julius allow multiple initial states: connect each initial node
      is not necesarry. */
   dfa_append(gdfa, m->dfa, m->state_begin, m->cate_begin);
+  /* if forward DFA is given, also append DFA states to global forward DFA, offsetting the same category ID as normal DFA */
   if (m->dfa_forward != NULL)
     dfa_append(gdfa_forward, m->dfa_forward, m->state_begin_forward, m->cate_begin);
   /* append words of src vocabulary to global winfo */

--- a/libjulius/src/wchmm.c
+++ b/libjulius/src/wchmm.c
@@ -75,6 +75,7 @@ wchmm_new()
   w->lmvar  = LM_UNDEF;
   w->ngram = NULL;
   w->dfa = NULL;
+  w->dfa_forward = NULL;
   w->winfo = NULL;
   w->malloc_root = NULL;
 #ifdef PASS1_IWCD

--- a/libsent/src/dfa/cpair.c
+++ b/libsent/src/dfa/cpair.c
@@ -274,6 +274,14 @@ void
 init_dfa_cp(DFA_INFO *dfa)
 {
   dfa->cp = NULL;
+  dfa->cplen = NULL;
+  dfa->cpalloclen = NULL;
+  dfa->cp_begin = NULL;
+  dfa->cp_begin_len = 0;
+  dfa->cp_begin_alloclen = 0;
+  dfa->cp_end = NULL;
+  dfa->cp_end_len = 0;
+  dfa->cp_end_alloclen = 0;
 }
 
 /** 
@@ -413,6 +421,8 @@ dfa_cp_output_rawdata(FILE *fp, DFA_INFO *dfa)
 {
   int i, j;
 
+  if (dfa->cp == NULL) return;
+
   for(i=0;i<dfa->term_num;i++) {
     fprintf(fp, "%d:", i);
     for(j=0;j<dfa->cplen[i];j++) {
@@ -437,6 +447,12 @@ dfa_cp_count_size(DFA_INFO *dfa, unsigned long *size_ret, unsigned long *allocsi
 {
   int i;
   unsigned long size, allocsize;
+
+  if (dfa->cp == NULL) {
+    *size_ret = 0;
+    *allocsize_ret = 0;
+    return;
+  }
 
   size = 0;
   allocsize = 0;


### PR DESCRIPTION
This pull request merges a newly implemented function "**grammar search on the 1st pass**". It enables applying full grammar on the 1-pass, thus outputs more reliable (grammar-constrained) result at the 1st pass.

## Background

The grammar-based recognition on Julius does not apply the full grammar on the 1st pass, but applies only the word-pair constraint extracted from the grammar for efficiency.  The errors on the 1st pass caused by the loose constraint will be recovered on the final pass, so the approximation basically does not impact on the final result.

However, there are cases in which the 1st pass result should be more precise, typically on a real-time application that aims to utilize the partial recognition output before audio input ends) 

## Effect

This update enables applying full grammar on the 1st pass.  When enabled, the generated word hypotheses on the 1st pass will be examined by the grammar parser at every frame and only the words that is allowed to connect on the context will be expanded. 

This feature is enabled when a recognition grammar (a set of `.dfa` and `.dict` files) has an additional dfa file (`.dfa.forward`).  This also works on multiple grammar recognition.  

No harm on old grammars, almost no impact on the recognition speed.

## Usage

- Re-run the updated grammar converter `mkdfa.pl` (or `mkdfa.py`) of the latest commit to your recognition grammar.  The output (.dfa, .dict) will be the same as the previous versions, but now it generates an extra file (`*.dfa.forward`).
- Run Julius with the generated grammar.   It additionally reads `.dfa.forward` file if it exists, and enable the new feature.  The (progressive) result always conforms the given grammar from the head.

## Restriction

You can not yet give the `.dfa.forward` file when throwing a grammar via module mode.  It is not implemented now.