### PR TITLE
Add initialization (NULL) of CLASS.next

### DIFF
--- a/gramtools/mkdfa/mkfa-1.44-flex/voca.c
+++ b/gramtools/mkdfa/mkfa-1.44-flex/voca.c
@@ -126,6 +126,7 @@ BODY *entryTerm( char *name, BODY *body, int listLen )
     class->usedFA = 0;
     class->used=0;
     class->tmp = 0;
+    class->next = NULL;
     if( ClassListTail == NULL ){
 	ClassList = class;
     } else {


### PR DESCRIPTION
The original code lacks initialization of CLASS.next in `voca.c` (after `malloc` in line 120).
It causes segmentation fault in `nfa.c` (`if( strcmp( class->name, name ) == 0 )` around line 431) if you build and run `mkfa.exe` in the MSYS2&MinGW64 environment.