### PR TITLE
fix build on Apple Silicon

### DIFF
--- a/libsent/src/phmm/calc_dnn.c
+++ b/libsent/src/phmm/calc_dnn.c
@@ -45,7 +45,7 @@ static void cpu_id_check()
 
   use_simd = USE_SIMD_NONE;
 
-#if defined(__arm__) || TARGET_OS_IPHONE
+#if defined(__arm__) || TARGET_OS_IPHONE || defined(__aarch64__)
   /* on ARM NEON */
 
 #if defined(HAS_SIMD_NEONV2)


### PR DESCRIPTION
Apple Silicon builds currently fail because this `ifdef` doesn't check for AArch64, and consequently tries to check for x86 extensions that don't exist on ARM.  This was the only change needed for the build to succeed.