### PR TITLE
libjulius: Fix incompatible types in POSIX threads configure checks

### DIFF
--- a/libjulius/configure
+++ b/libjulius/configure
@@ -4532,7 +4532,7 @@ $as_echo_n "checking for linking POSIX threaded process... " >&6; }
 int
 main ()
 {
-pthread_equal(NULL,NULL);
+pthread_equal(pthread_self(),pthread_self());
   ;
   return 0;
 }
@@ -4564,7 +4564,7 @@ $as_echo_n "checking for POSIX thread library in -lpthread... " >&6; }
 int
 main ()
 {
-pthread_equal(NULL,NULL);
+pthread_equal(pthread_self(),pthread_self());
   ;
   return 0;
 }

--- a/libjulius/configure.in
+++ b/libjulius/configure.in
@@ -373,7 +373,8 @@ if test "$want_pthread" = yes; then
 	AC_MSG_CHECKING([for linking POSIX threaded process])
  	ac_save_CFLAGS="$CFLAGS"
  	CFLAGS="$CFLAGS -pthread"
- 	AC_TRY_LINK([#include <pthread.h>],[pthread_equal(NULL,NULL);],
+ 	AC_TRY_LINK([#include <pthread.h>],
+		    [pthread_equal(pthread_self(),pthread_self());],
      	    use_pthread=yes
      	    AC_DEFINE(HAVE_PTHREAD)
 	    CPPFLAGS="$CPPFLAGS -pthread",
@@ -388,7 +389,8 @@ if test "$want_pthread" = yes; then
 	AC_MSG_CHECKING([for POSIX thread library in -lpthread])
 	ac_save_LIBS_p="$LIBS"
 	LIBS="$LIBS -lpthread"
-	AC_TRY_LINK([#include <pthread.h>],[pthread_equal(NULL,NULL);],
+	AC_TRY_LINK([#include <pthread.h>],
+	            [pthread_equal(pthread_self(),pthread_self());],
 	    use_pthread=yes
 	    AC_DEFINE(HAVE_PTHREAD),
 	  use_pthread=no


### PR DESCRIPTION
NULL is not necessarily a valid `pthread_t` value.  Compilers increasingly enforce C type safety, and these configure checks may fail incorrectly with such compilers.  POSIX guarantees that `pthread_self()` returns a valid `pthread_t` value, so use that instead.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
