### PR TITLE
cast header_len to char *, so we can properly use swap_bytes()

### DIFF
--- a/libsent/src/phmm/calc_dnn.c
+++ b/libsent/src/phmm/calc_dnn.c
@@ -284,7 +284,7 @@ static boolean load_npy(float *array, char *filename, int x, int y)
     return FALSE;
   }
 #ifdef WORDS_BIGENDIAN
-  swap_bytes(&header_len, 2, 1);
+  swap_bytes((char *)&header_len, 2, 1);
 #endif
   header = (char *)mymalloc(header_len + 1);
   if ((len = myfread(header, 1, header_len, fp)) < header_len) {


### PR DESCRIPTION
&header_len is a short unsigned int *, which swap_bytes() isn't expecting. Casting it to char * gives it what it expects (and matches other behavior in the julius code).